### PR TITLE
Verify Linux desktop MIME registration

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,6 +55,23 @@ jobs:
           cat "$entry"
           grep -q 'x-scheme-handler/d2mm' "$entry"
 
+      - name: Register and verify the desktop entry
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$HOME/.local/share/applications"
+
+          cp dist/squashfs-root/*.desktop \
+            "$HOME/.local/share/applications/dota2-mod-manager.desktop"
+
+          update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+
+          xdg-mime default dota2-mod-manager.desktop x-scheme-handler/d2mm
+          xdg-mime default dota2-mod-manager.desktop application/x-d2mm
+
+          test "$(xdg-mime query default x-scheme-handler/d2mm)" = "dota2-mod-manager.desktop"
+          test "$(xdg-mime query default application/x-d2mm)" = "dota2-mod-manager.desktop"
+
       - uses: actions/upload-artifact@v7
         with:
           name: AppImage


### PR DESCRIPTION
## What this changes

Adds Linux desktop integration checks for the `d2mm://` preset-link scheme and `.d2mm` files. The Linux CI now registers the AppImage desktop entry with XDG and verifies both default associations. Fixes #7.

## How to see it work

Build the Linux AppImage with:

`npx electron-builder --linux --publish never`

The Linux workflow then verifies that the AppImage desktop entry declares `d2mm://` and registers both the `d2mm://` scheme and `.d2mm` MIME type through XDG.

## Checks

- [x] `npm test` is green
- [ ] Tried it in the sandbox (`npm run sandbox:seed`, `npm run start:sandbox`), not against a real Dota install
- [ ] New user-facing strings exist in both Russian and English (`renderer/i18n.js`, `src/i18n.js`)
- [ ] Screenshots below, if anything visual changed
- [ ] Behaviour in `patcher`, `vpk`, `gamelang` or `schema` brings its own test